### PR TITLE
Removed $_SERVER['REQUEST_SCHEME'] from redirect.

### DIFF
--- a/gp-require-login.php
+++ b/gp-require-login.php
@@ -20,7 +20,7 @@ class GP_Require_Login {
 	
 	public function gp_router_http_methods( $methods ) {
 		if( ! is_user_logged_in() ) {
-			wp_redirect( wp_login_url( $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) );
+			wp_redirect( wp_login_url( '//' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) );
 			exit;
 		}
 		


### PR DESCRIPTION
Request scheme is unreliable (may not exists based on server configuration). If we want to redirect to current scheme, it is not needed, though. We may use URL syntax starting with double slash, meaning "maintain current scheme".